### PR TITLE
chore(test): require angular2-polyfills

### DIFF
--- a/karma.entry.js
+++ b/karma.entry.js
@@ -1,7 +1,4 @@
-require('reflect-metadata');
-require('zone.js/dist/zone-microtask.js');
-require('zone.js/dist/long-stack-trace-zone.js');
-require('zone.js/dist/jasmine-patch.js');
+require('angular2/bundles/angular2-polyfills');
 require('angular2/testing');
 
 

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -20,9 +20,7 @@ module.exports = {
     ],
 
     noParse: [
-      /zone\.js\/dist\/jasmine-patch\.js/,
-      /zone\.js\/dist\/long-stack-trace-zone\.js/,
-      /zone\.js\/dist\/zone-microtask\.js/
+      /angular2\/bundles\/.+/
     ]
   }
 };


### PR DESCRIPTION
Use `angular2-polyfills.js` instead of individually requiring `reflect-metadata` and `zone.js`